### PR TITLE
Swagger URL instead of obsolete WeatherForecast.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Getting the App Running:
 7.<code>dotnet run</code>
 
 8.At this point you should be able to open a browser window at
-[https://localhost:5001/weatherforecast] and see the the "WeatherForecast.cs" project. I had to run <code>dotnet run</code> a couple of times as my machine did not connect right away. I also had a security warning the first time I attempted running this project locally, adjust you settings accordingly.
+[https://localhost:5001/swagger/index.html] and see the Swagger interface. I had to run <code>dotnet run</code> a couple of times as my machine did not connect right away. I also had a security warning the first time I attempted running this project locally, adjust you settings accordingly. (Or use the HTTP interface at [http://localhost:5000/swagger/index.html].)
 
 9.control c
 

--- a/api/Emailer/Controllers/DefaultController.cs
+++ b/api/Emailer/Controllers/DefaultController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Emailer.Controllers
 {
+    [ApiExplorerSettings(IgnoreApi = true)]
     [ApiVersion("1.0")]
     [ApiController]
     [Route("[controller]")]

--- a/api/Emailer/Controllers/DefaultController.cs
+++ b/api/Emailer/Controllers/DefaultController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Emailer.Controllers
+{
+    [ApiVersion("1.0")]
+    [ApiController]
+    [Route("[controller]")]
+    public class DefaultController : ControllerBase
+    {
+        [HttpGet("/")]
+        [HttpHead("/")]
+        public IActionResult Index()
+        {
+            return new RedirectResult("~/swagger/index.html");
+        }
+    }
+}


### PR DESCRIPTION
Instructions don't work because weather forecast controller had been removed. Changed to Swagger interface mentioned in class